### PR TITLE
Fix per-file step creation

### DIFF
--- a/smol_dev/api.py
+++ b/smol_dev/api.py
@@ -32,12 +32,13 @@ async def _generate_file_paths(task: Task, step: Step) -> Step:
     shared_deps = step.additional_properties["shared_deps"]
     file_paths = specify_file_paths(task.input, shared_deps)
     for file_path in file_paths[:-1]:
+        # create a step for each file and store its path for the code generation stage
         await Agent.db.create_step(
             task.task_id,
             f"Generate code for {file_path}",
             additional_properties={
                 "shared_deps": shared_deps,
-                "file_path": file_paths[-1],
+                "file_path": file_path,
             },
         )
 


### PR DESCRIPTION
## Summary
- ensure `_generate_file_paths` stores each file path in its own step
- clarify the step creation loop

## Testing
- `pytest -q`
- run a stub script to call `_generate_file_paths` and verify stored file paths

------
https://chatgpt.com/codex/tasks/task_e_68416b942390832b95ed72acf439dd07