### PR TITLE
Add retry to planning functions with tests

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import smol_dev.prompts as prompts
+
+
+def test_retry_specify_file_paths():
+    call_count = {"count": 0}
+
+    def fake_generate_chat(*args, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] < 2:
+            raise ValueError("fail")
+        return '["file1.py"]'
+
+    with patch.object(prompts, "generate_chat", side_effect=fake_generate_chat):
+        result = prompts.specify_file_paths("prompt", "plan")
+    assert result == ["file1.py"]
+    assert call_count["count"] == 2
+
+
+def test_retry_plan():
+    call_count = {"count": 0}
+
+    def fake_generate_chat(*args, **kwargs):
+        call_count["count"] += 1
+        if call_count["count"] < 3:
+            raise ValueError("fail")
+        return "plan-text"
+
+    with patch.object(prompts, "generate_chat", side_effect=fake_generate_chat):
+        result = prompts.plan("prompt")
+    assert result == "plan-text"
+    assert call_count["count"] == 3


### PR DESCRIPTION
## Summary
- apply retry logic to `plan` and `specify_file_paths`
- provide fallbacks for optional dependencies
- add tests covering retry behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bb6fcb4832b857a7219d3549cc9