### PR TITLE
Add pytest tests and docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ tenacity = "^8.2.2"
 agent-protocol = "^1.0.0"
 transformers = "^4.38.2"
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4"
+coverage = "^7.4"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/readme.md
+++ b/readme.md
@@ -166,6 +166,13 @@ async with ApiClient() as api_client:
 
 ```
 
+### Running tests
+Use [pytest](https://pytest.org) to run the test suite:
+
+```bash
+poetry run pytest
+```
+
 ## examples/prompt gallery
 
 - [6 minute video demo](https://youtu.be/UCo7YeTy-aE) - (sorry for sped up audio, we were optimizing for twitter, bad call)

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,51 @@
+import pytest
+import sys
+import types
+import importlib.util
+from pathlib import Path
+
+sys.modules.setdefault(
+    "openai_function_call",
+    types.SimpleNamespace(
+        openai_function=lambda f: setattr(f, "openai_schema", {}) or f
+    ),
+)
+sys.modules.setdefault(
+    "tenacity",
+    types.SimpleNamespace(
+        retry=lambda *a, **k: (lambda f: f),
+        stop_after_attempt=lambda *a, **k: None,
+        wait_random_exponential=lambda *a, **k: None,
+    ),
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+LLM_PATH = ROOT / "smol_dev" / "llm.py"
+PROMPTS_PATH = ROOT / "smol_dev" / "prompts.py"
+
+llm_spec = importlib.util.spec_from_file_location("smol_dev.llm", LLM_PATH)
+llm = importlib.util.module_from_spec(llm_spec)
+llm_spec.loader.exec_module(llm)
+sys.modules.setdefault("smol_dev", types.ModuleType("smol_dev"))
+sys.modules["smol_dev.llm"] = llm
+
+prompts_spec = importlib.util.spec_from_file_location("smol_dev.prompts", PROMPTS_PATH)
+prompts = importlib.util.module_from_spec(prompts_spec)
+prompts_spec.loader.exec_module(prompts)
+
+
+def test_specify_file_paths_returns_list(monkeypatch):
+    def fake_generate_chat(messages, model, backend, **kwargs):
+        return '["main.py", "utils.py"]'
+    monkeypatch.setattr(prompts, "generate_chat", fake_generate_chat)
+    result = prompts.specify_file_paths("prompt", "plan")
+    assert result == ["main.py", "utils.py"]
+
+
+def test_generate_code_sync_strips_fences(monkeypatch):
+    def fake_generate_chat(messages, model, backend, **kwargs):
+        return "```python\nprint('hi')\n```"
+    monkeypatch.setattr(prompts, "generate_chat", fake_generate_chat)
+    code = prompts.generate_code_sync("prompt", "plan", "main.py")
+    assert "```" not in code
+    assert code.strip() == "print('hi')"


### PR DESCRIPTION
## Summary
- create `tests/` with initial pytest suite
- test file path planning and code generation helpers
- add `pytest` and `coverage` dev dependencies
- document how to run the tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68416bbfe628832bae0799ed0ed185cb