### PR TITLE
Add persistent chat response cache

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,8 @@ python main.py --prompt prompt.md --debug True # for debugging
 python main.py "a HTML/JS/CSS Tic Tac Toe Game" --backend hf --hf-model <model-or-path>
 # Models loaded via the hf backend are cached for the life of the process to avoid
 # repeatedly loading the tokenizer and model from disk.
+# Chat responses are cached on disk. Set `SMOL_DEV_CACHE_PATH` to change
+# the cache location (defaults to `~/.smol_dev_cache`).
 # if using LMStudio or Ollama set environment variables to point transformers to the model directory
 ```
 

--- a/smol_dev/llm.py
+++ b/smol_dev/llm.py
@@ -1,4 +1,8 @@
 from typing import List, Dict, Tuple
+import json
+import os
+import hashlib
+import shelve
 
 try:
     import openai
@@ -13,34 +17,48 @@ except Exception:  # pragma: no cover - transformers optional
 
 _hf_models: Dict[str, Tuple[object, object]] = {}
 
+# path to persistent cache used to store chat responses
+_cache_path = os.environ.get("SMOL_DEV_CACHE_PATH", os.path.expanduser("~/.smol_dev_cache"))
+
 
 def generate_chat(messages: List[Dict[str, str]], model: str, backend: str = "openai", **kwargs) -> str:
-    """Generate chat completion text from either OpenAI or HuggingFace backend."""
-    if backend == "openai":
-        if openai is None:
-            raise ImportError("openai package not available")
-        response = openai.ChatCompletion.create(model=model, messages=messages, **kwargs)
-        msg = response["choices"][0]["message"]
-        if msg.get("content") is not None:
-            return msg["content"]
-        if msg.get("function_call"):
-            return msg["function_call"].get("arguments", "")
-        return ""
-    elif backend == "hf":
-        if AutoModelForCausalLM is None or AutoTokenizer is None:
-            raise ImportError("transformers package not available")
+    """Generate chat completion text from either OpenAI or HuggingFace backend with caching."""
+    key_data = json.dumps({"messages": messages, "model": model, "backend": backend, "kwargs": kwargs}, sort_keys=True)
+    key = hashlib.sha256(key_data.encode("utf-8")).hexdigest()
 
-        tokenizer, model_obj = _hf_models.get(model, (None, None))
-        if tokenizer is None or model_obj is None:
-            tokenizer = AutoTokenizer.from_pretrained(model)
-            model_obj = AutoModelForCausalLM.from_pretrained(model)
-            _hf_models[model] = (tokenizer, model_obj)
+    with shelve.open(_cache_path) as cache:
+        if key in cache:
+            return cache[key]
 
-        prompt_text = "".join(f"{m['role']}: {m['content']}\n" for m in messages)
-        input_ids = tokenizer.encode(prompt_text, return_tensors="pt")
-        max_new_tokens = kwargs.get("max_tokens", 256)
-        output = model_obj.generate(input_ids, max_new_tokens=max_new_tokens)
-        text = tokenizer.decode(output[0], skip_special_tokens=True)
-        return text[len(prompt_text) :].strip()
-    else:
-        raise ValueError(f"Unsupported backend: {backend}")
+        if backend == "openai":
+            if openai is None:
+                raise ImportError("openai package not available")
+            response = openai.ChatCompletion.create(model=model, messages=messages, **kwargs)
+            msg = response["choices"][0]["message"]
+            if msg.get("content") is not None:
+                result = msg["content"]
+            elif msg.get("function_call"):
+                result = msg["function_call"].get("arguments", "")
+            else:
+                result = ""
+        elif backend == "hf":
+            if AutoModelForCausalLM is None or AutoTokenizer is None:
+                raise ImportError("transformers package not available")
+
+            tokenizer, model_obj = _hf_models.get(model, (None, None))
+            if tokenizer is None or model_obj is None:
+                tokenizer = AutoTokenizer.from_pretrained(model)
+                model_obj = AutoModelForCausalLM.from_pretrained(model)
+                _hf_models[model] = (tokenizer, model_obj)
+
+            prompt_text = "".join(f"{m['role']}: {m['content']}\n" for m in messages)
+            input_ids = tokenizer.encode(prompt_text, return_tensors="pt")
+            max_new_tokens = kwargs.get("max_tokens", 256)
+            output = model_obj.generate(input_ids, max_new_tokens=max_new_tokens)
+            text = tokenizer.decode(output[0], skip_special_tokens=True)
+            result = text[len(prompt_text) :].strip()
+        else:
+            raise ValueError(f"Unsupported backend: {backend}")
+
+        cache[key] = result
+        return result

--- a/tests/test_llm_cache.py
+++ b/tests/test_llm_cache.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import shelve
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import smol_dev.llm as llm
+
+
+messages = [{"role": "user", "content": "hi"}]
+
+
+def test_generate_chat_caches(tmp_path, monkeypatch):
+    cache_file = tmp_path / "cache"
+    monkeypatch.setenv("SMOL_DEV_CACHE_PATH", str(cache_file))
+    monkeypatch.setattr(llm, "_cache_path", str(cache_file))
+
+    call_count = {"n": 0}
+
+    def fake_create(**kwargs):
+        call_count["n"] += 1
+        return {"choices": [{"message": {"content": "hello"}}]}
+
+    fake_openai = SimpleNamespace(ChatCompletion=SimpleNamespace(create=fake_create))
+
+    with patch.object(llm, "openai", fake_openai):
+        result1 = llm.generate_chat(messages, "test-model")
+        assert result1 == "hello"
+        assert call_count["n"] == 1
+
+    with shelve.open(str(cache_file)) as cache:
+        assert len(cache) == 1
+
+    def should_not_call(**kwargs):
+        raise AssertionError("backend called")
+
+    fake_openai2 = SimpleNamespace(ChatCompletion=SimpleNamespace(create=should_not_call))
+
+    with patch.object(llm, "openai", fake_openai2):
+        result2 = llm.generate_chat(messages, "test-model")
+        assert result2 == "hello"
+
+    with shelve.open(str(cache_file)) as cache:
+        assert len(cache) == 1


### PR DESCRIPTION
## Summary
- implement simple disk-based caching for `generate_chat`
- document `SMOL_DEV_CACHE_PATH`
- test that caching avoids repeated backend calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841721d22d4832b9871bae90d0dc5ff