### PR TITLE
Add tests for self-heal logic and CLI

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+import textwrap
+
+
+def test_cli_execution(tmp_path):
+    runner = tmp_path / "runner.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import runpy
+            import sys
+            import unittest.mock
+            from pathlib import Path
+            import smol_dev.prompts as prompts
+
+            def fake_plan(*args, **kwargs):
+                return "plan"
+
+            def fake_specify(*args, **kwargs):
+                return ["main.py"]
+
+            def fake_generate(*args, **kwargs):
+                return "print('hi')"
+
+            with unittest.mock.patch.object(prompts, 'plan', fake_plan), \
+                 unittest.mock.patch.object(prompts, 'specify_file_paths', fake_specify), \
+                 unittest.mock.patch.object(prompts, 'generate_code_sync', fake_generate):
+                sys.argv = ['smol_dev.main', '--prompt', 'x', '--generate_folder_path', str(Path('out'))]
+                runpy.run_module('smol_dev.main', run_name='__main__')
+            """
+        )
+    )
+
+    env = dict(**os.environ)
+    env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run([sys.executable, str(runner)], cwd=tmp_path, capture_output=True, text=True, env=env)
+    assert result.returncode == 0
+    assert (tmp_path / "out" / "main.py").exists()
+    assert (tmp_path / "out" / "shared_deps.md").exists()

--- a/tests/test_self_heal.py
+++ b/tests/test_self_heal.py
@@ -1,0 +1,52 @@
+import subprocess
+from types import SimpleNamespace
+
+import smol_dev.self_heal as self_heal
+
+
+# tests will patch self_heal._run to simulate script execution
+
+
+def make_cp(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=["python", "script.py"], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_run_and_fix_installs_missing_package(monkeypatch):
+    calls = {"runs": 0, "pip": 0}
+
+    def fake_run(entry, python_exec):
+        calls["runs"] += 1
+        if calls["runs"] == 1:
+            return make_cp(1, stderr="ModuleNotFoundError: No module named 'foo'")
+        return make_cp(0, stdout="done")
+
+    def fake_subprocess_run(cmd, capture_output=True, text=True):
+        calls["pip"] += 1
+        assert "install" in cmd
+        return make_cp(0, stdout="installed")
+
+    monkeypatch.setattr(self_heal, "_run", fake_run)
+    monkeypatch.setattr(self_heal, "subprocess", SimpleNamespace(run=fake_subprocess_run))
+
+    result = self_heal.run_and_fix("entry.py")
+    assert result["stdout"] == "done"
+    assert result["pip_stdout"] == "installed"
+    assert result["error"]["error_type"] is None
+    assert calls["runs"] == 2
+    assert calls["pip"] == 1
+
+
+def test_run_and_fix_syntax_error(monkeypatch):
+    def fake_run(entry, python_exec):
+        return make_cp(1, stderr="SyntaxError: invalid syntax")
+
+    def should_not_call(*a, **k):
+        raise AssertionError("pip install should not run")
+
+    monkeypatch.setattr(self_heal, "_run", fake_run)
+    monkeypatch.setattr(self_heal, "subprocess", SimpleNamespace(run=should_not_call))
+
+    result = self_heal.run_and_fix("entry.py")
+    assert result["error"]["error_type"] == "SyntaxError"
+    assert "pip_stdout" not in result
+


### PR DESCRIPTION
## Summary
- add tests covering run_and_fix error handling
- add CLI integration test executed via subprocess

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417cb0d16c832b955d7e622d501e11