### PR TITLE
Fix LICENSE EOL and update Makefile clean rule

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,21 @@
-MIT License Copyright (c) 2023 swyx
+MIT License
 
-Permission is hereby granted, free of
-charge, to any person obtaining a copy of this software and associated
-documentation files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to the
-following conditions:
+Copyright (c) 2023 swyx
 
-The above copyright notice and this permission notice
-(including the next paragraph) shall be included in all copies or substantial
-portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
-EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
-OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,14 @@
 .PHONY: clean build publish
 
 build: clean
-	python -m pip install --upgrade --quiet setuptools wheel twine
-	python3 -m build
-	# python setup.py --quiet sdist bdist_wheel
+python -m pip install --upgrade --quiet setuptools wheel twine
+python3 -m build
+# python setup.py --quiet sdist bdist_wheel
 
 publish: build
-	python -m twine check dist/*
-	# python -m twine upload dist/*
-	python3 -m twine upload dist/*
+python -m twine check dist/*
+# python -m twine upload dist/*
+python3 -m twine upload dist/*
 
 clean:
-	rm -r build dist *.egg-info || true
+rm -rf build dist *.egg-info


### PR DESCRIPTION
## Summary
- standardize MIT `LICENSE` with proper newlines
- add a more complete `clean` rule
- ensure final newline in `LICENSE` and `Makefile`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68417cb9336c832b8198d1058359cebd