### PR TITLE
Implement cache expiration

### DIFF
--- a/smol_dev/llm.py
+++ b/smol_dev/llm.py
@@ -3,6 +3,7 @@ import json
 import os
 import hashlib
 import shelve
+import time
 
 try:
     import openai
@@ -21,14 +22,30 @@ _hf_models: Dict[str, Tuple[object, object]] = {}
 _cache_path = os.environ.get("SMOL_DEV_CACHE_PATH", os.path.expanduser("~/.smol_dev_cache"))
 
 
+def _get_cache_ttl() -> float:
+    """Return cache TTL in seconds, 0 for no expiration."""
+    try:
+        return float(os.environ.get("SMOL_DEV_CACHE_TTL", "0"))
+    except ValueError:  # pragma: no cover - bad env var
+        return 0.0
+
+
 def generate_chat(messages: List[Dict[str, str]], model: str, backend: str = "openai", **kwargs) -> str:
     """Generate chat completion text from either OpenAI or HuggingFace backend with caching."""
     key_data = json.dumps({"messages": messages, "model": model, "backend": backend, "kwargs": kwargs}, sort_keys=True)
     key = hashlib.sha256(key_data.encode("utf-8")).hexdigest()
 
+    cache_ttl = _get_cache_ttl()
+
     with shelve.open(_cache_path) as cache:
         if key in cache:
-            return cache[key]
+            entry = cache[key]
+            # handle legacy string caches
+            if isinstance(entry, dict) and "value" in entry and "time" in entry:
+                if cache_ttl <= 0 or time.time() - entry["time"] <= cache_ttl:
+                    return entry["value"]
+            elif cache_ttl <= 0:
+                return entry
 
         if backend == "openai":
             if openai is None:
@@ -60,5 +77,5 @@ def generate_chat(messages: List[Dict[str, str]], model: str, backend: str = "op
         else:
             raise ValueError(f"Unsupported backend: {backend}")
 
-        cache[key] = result
+        cache[key] = {"value": result, "time": time.time()}
         return result


### PR DESCRIPTION
## Summary
- add optional TTL to LLM cache
- test cache expiry behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68417e1134b8832baadb8fe7219c5626

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added cache expiration support for chat responses, allowing cached results to expire after a configurable time period.
- **Tests**
	- Introduced tests to verify correct cache expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->