### PR TITLE
Fix URLs section

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,6 @@ build-backend = "poetry.core.masonry.api"
 src = "src.__main__:main"
 api = "smol_dev.api:main"
 
-[project.urls]
+[tool.poetry.urls]
 "Homepage" = "https://github.com/smol-ai/developer"
 "Bug Tracker" = "https://github.com/smol-ai/developer/issues"


### PR DESCRIPTION
## Summary
- move the `project.urls` table to `tool.poetry.urls`

## Testing
- `poetry check` *(fails: pyproject.toml changed significantly since poetry.lock was last generated)*

------
https://chatgpt.com/codex/tasks/task_e_688b9abdfc14832ba456f1b0e141a808