### PR TITLE
Clarify OpenAI version requirement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@
    ```bash
    poetry install
    ```
+   Esto fija todas las versiones, incluida `openai==0.27.8`. Si instalas las
+   dependencias manualmente asegúrate de usar esa versión, ya que OpenAI
+   `>=1.0` no está soportado y puede provocar errores `APIRemovedInV1`.
 3. Configura tu entorno:
    - exporta tu clave de OpenAI para usar el backend por defecto. Si no la
      defines, el programa intentará conectarse a un servidor Ollama en


### PR DESCRIPTION
## Summary
- mention that `openai==0.27.8` is expected
- warn that OpenAI 1.0+ is unsupported and may raise `APIRemovedInV1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba4a54fac832b9663d38cbda64e48