### PR TITLE
Add watch flag to regenerate on prompt updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ python main.py "a HTML/JS/CSS Tic Tac Toe Game" # defaults to gpt-4-0613
 python main.py --prompt prompt.md # for longer prompts, move them into a markdown file
 python main.py --prompt prompt.md --debug True # for debugging
 python main.py --prompt prompt.md --file-prompts-dir ./my_prompts # use per-file prompt overrides
+python main.py --prompt prompt.md --watch # regenerate whenever the prompt changes
 # using a local HuggingFace model
 python main.py "a HTML/JS/CSS Tic Tac Toe Game" --backend hf --hf-model <model-or-path>
 # Models loaded via the hf backend are cached for the life of the process to avoid
@@ -298,4 +299,5 @@ things to try/would accept open issue discussions and PRs:
   - you can run `modal run anthropic.py --prompt prompt.md --outputdir=anthropic` to try it
   - but it doesnt work because anthropic doesnt follow instructions to generate file code very well.
 - **make agents that autonomously run this code in a loop/watch the prompt file** and regenerate code each time, on a new git branch
+  - enable with `--watch` to automatically rerun generation whenever the prompt file changes
   - the code could be generated on 5 simultaneous git branches and checking their output would just involve switching git branches

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -75,3 +75,59 @@ def test_cli_requires_hf_model(tmp_path):
     env["PYTHONPATH"] = os.getcwd()
     result = subprocess.run([sys.executable, str(runner)], cwd=tmp_path, capture_output=True, text=True, env=env)
     assert result.returncode != 0
+
+
+def test_cli_watch_triggers_generation(tmp_path):
+    runner = tmp_path / "runner_watch.py"
+    runner.write_text(
+        textwrap.dedent(
+            """
+            import sys
+            import unittest.mock
+            from pathlib import Path
+            import smol_dev.main as smain
+            import time
+
+            def fake_plan(*a, **k):
+                return "plan"
+
+            def fake_specify(*a, **k):
+                return ["main.py"]
+
+            calls = {"n": 0}
+
+            def fake_generate(*a, **k):
+                calls["n"] += 1
+                return "print('hi')"
+
+            def fake_watch(path, cb, interval=1.0):
+                cb()
+
+            with unittest.mock.patch.object(smain, 'plan', fake_plan), \
+                 unittest.mock.patch.object(smain, 'specify_file_paths', fake_specify), \
+                 unittest.mock.patch.object(smain, 'generate_code_sync', fake_generate), \
+                 unittest.mock.patch.object(smain, 'watch_prompt_file', fake_watch), \
+                 unittest.mock.patch.object(time, 'strftime', lambda fmt: 'ts'):
+                p = Path('prompt.md')
+                p.write_text('x')
+                # replicate CLI logic
+                def run_once():
+                    smain.main(
+                        prompt=p.read_text(),
+                        generate_folder_path='out_ts',
+                        backend='openai',
+                    )
+
+                run_once()
+                smain.watch_prompt_file(str(p), run_once)
+
+            print('COUNT', calls['n'])
+            """
+        )
+    )
+
+    env = dict(**os.environ)
+    env["PYTHONPATH"] = os.getcwd()
+    result = subprocess.run([sys.executable, str(runner)], cwd=tmp_path, capture_output=True, text=True, env=env)
+    assert result.returncode == 0
+    assert "COUNT 2" in result.stdout


### PR DESCRIPTION
## Summary
- allow watching prompt for changes in both entrypoints
- implement `watch_prompt_file` using `watchdog` or polling
- document `--watch` flag in README
- test CLI watch behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9d82eb3c832b8b65297282b8f0d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new --watch command-line option that enables automatic regeneration of code whenever the prompt file changes. Each regeneration outputs to a uniquely timestamped directory.
* **Documentation**
  * Updated usage instructions and examples in the documentation to describe the new --watch feature.
* **Tests**
  * Introduced a test to verify that the watch mechanism correctly triggers code generation on prompt file changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->