### PR TITLE
Add container runtime execution option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,7 @@ things to try/would accept open issue discussions and PRs:
 - **self-heal** by running the code itself and use errors as information for reprompting
   - enable with `--self-heal` to execute the generated `main.py` after scaffolding
   - missing Python packages are installed automatically with `pip` inside the optional `--venv-path` environment
+  - run the self-heal step inside Docker or Podman with `--container-runtime docker`
 - **using anthropic as the coding layer**
   - you can run `modal run anthropic.py --prompt prompt.md --outputdir=anthropic` to try it
   - but it doesnt work because anthropic doesnt follow instructions to generate file code very well.


### PR DESCRIPTION
## Summary
- allow `self_heal` to run in docker/podman by mapping the workspace
- expose runtime via new tests
- document `--container-runtime` flag

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b9d74bec0832bab581f5887f214b6