### PR TITLE
Clean up CLI tests and expose public API

### DIFF
--- a/smol_dev/__init__.py
+++ b/smol_dev/__init__.py
@@ -1,4 +1,19 @@
-from smol_dev.prompts import *
+from smol_dev.prompts import (
+    file_paths,
+    specify_file_paths,
+    plan,
+    generate_code,
+    generate_code_sync,
+)
 from smol_dev.self_heal import run_and_fix
+
+__all__ = [
+    "file_paths",
+    "specify_file_paths",
+    "plan",
+    "generate_code",
+    "generate_code_sync",
+    "run_and_fix",
+]
 
 __author__ = "morph"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
 import textwrap
 
 


### PR DESCRIPTION
## Summary
- drop unused `Path` import from tests
- explicitly import functions in `smol_dev.__init__`
- define `__all__` for public API re-exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc2ebab00832b92fa6ed044671507

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved package structure by explicitly defining the public API, ensuring clearer and more predictable imports for users.
  * Cleaned up unused imports in test files for better code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->