### PR TITLE
Clean up CLI tests and expose public API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ pip install smol_dev
 Here you can basically look at the contents of `main.py` as our "documentation" of how you can use these functions and prompts in your own app:
 
 ```python
-from smol_dev.prompts import plan, specify_file_paths, generate_code_sync
+from smol_dev import plan, specify_file_paths, generate_code_sync
 
 prompt = "a HTML/JS/CSS Tic Tac Toe Game"
 

--- a/smol_dev/__init__.py
+++ b/smol_dev/__init__.py
@@ -1,4 +1,19 @@
-from smol_dev.prompts import *
+from smol_dev.prompts import (
+    file_paths,
+    specify_file_paths,
+    plan,
+    generate_code,
+    generate_code_sync,
+)
 from smol_dev.self_heal import run_and_fix
+
+__all__ = [
+    "file_paths",
+    "specify_file_paths",
+    "plan",
+    "generate_code",
+    "generate_code_sync",
+    "run_and_fix",
+]
 
 __author__ = "morph"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 import sys
-from pathlib import Path
 import textwrap
 
 


### PR DESCRIPTION
## Summary
- drop unused `Path` import from tests
- explicitly import functions in `smol_dev.__init__`
- define `__all__` for public API re-exports
- document new root-level imports in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688bc2ebab00832b92fa6ed044671507